### PR TITLE
Conditional Weather

### DIFF
--- a/1080i/Includes_Weather.xml
+++ b/1080i/Includes_Weather.xml
@@ -196,7 +196,8 @@
                         <label>$VAR[Weather_UVIndex_Info]</label>
                     </control>
                 </control>
-            </control>      
+            </control>
+            <visible>Weather.IsFetched</visible>
         </control>
         <control type="grouplist">
             <left>view_pad</left>
@@ -294,6 +295,7 @@
                 <label fallback="31411">$INFO[Window(Weather).Property($PARAM[day].Outlook),,]</label>
             </control>
         </control>
+        <visible>Weather.IsFetched</visible>
     </include>
 
     <variable name="Weather_Sunrise">


### PR DESCRIPTION
Thought I'd suggest this, since I already have inside Auramod.

Add's conditional weather by adding: `<visible>Weather.IsFetched</visible>`
This is so that null info isn't displayed for people who don't use weather. 

FROM:
![2022-03-07 17_25_41-Greenshot](https://user-images.githubusercontent.com/17692472/157148637-960d58db-3d74-47b9-bda2-e1701a2bffb2.png)

********************************************************

TO:
![2022-03-07 17_32_21-Greenshot](https://user-images.githubusercontent.com/17692472/157148669-0d630d26-023a-4942-8b74-cd0b402309df.png)

********************************************************

I was trying to get system info to display when there isn't info supplied, so the page isn't just empty, but I haven't been able to figure it out yet. 

There is also a "bug" in this, if you already have weather info supplied and you disable it in settings it takes 20min(ish) for it to refresh, leaving the weather background still displayed. I'm pretty sure you just have to add the visibility condition on that part of the code. I just don't know where that is. 

 